### PR TITLE
Better babel plugin import integration

### DIFF
--- a/build/build-lib.js
+++ b/build/build-lib.js
@@ -62,9 +62,10 @@ function renderIndexFile (pkgs) {
   const importStatmentsArray = []
   for (let i = 0; i < pkgs.length; i++) {
     const pkg = pkgs[i]
+    const camelCasedPkg = camelCase(pkg)
     importStatmentsArray.push(
       render(tmpl, {
-        name: capitalize(camelCase(pkg)),
+        name: ['util', 'form', 'text'].includes(pkg) ? camelCasedPkg : capitalize(camelCasedPkg),
         package: pkg
       })
     )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibot/ibot",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibot/ibot",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibot/ibot",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibot/ibot",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibot/ibot",
-  "version": "0.3.7",
+  "version": "0.3.8-beta.1",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "license": "MIT",

--- a/packages/button/index.js
+++ b/packages/button/index.js
@@ -2,9 +2,10 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import Icon from '@ibot/icon'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 
 import './index.styl'
+const { trimList } = Util
 
 const CLASS_MAP = {
   primary: 'PrimaryButton',

--- a/packages/button/index.js
+++ b/packages/button/index.js
@@ -2,10 +2,10 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import Icon from '@ibot/icon'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import './index.styl'
-const { trimList } = Util
+const { trimList } = util
 
 const CLASS_MAP = {
   primary: 'PrimaryButton',

--- a/packages/dropdown/index.js
+++ b/packages/dropdown/index.js
@@ -2,10 +2,9 @@ import React, { PureComponent } from 'react'
 import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import DocumentEvents from 'react-document-events'
-
-import { trimList, $, SVG } from '@ibot/util'
-
+import Util from '@ibot/util'
 import './index.styl'
+const { trimList, $, SVG } = Util
 
 const MENU_ROOT_ID = 'MB_DROPDOWN_MENU_ROOT'
 const { I18N = {} } = window
@@ -21,7 +20,7 @@ if (!$body.contains($menuRoot)) {
   $body.appendChild($menuRoot)
 }
 
-export default class Dropdown extends PureComponent {
+class Dropdown extends PureComponent {
   constructor(props) {
     super(props)
 
@@ -356,7 +355,7 @@ class DropdownMenu extends PureComponent {
  *  @prop {Object} style
  *  @prop {String} finalPosition
  */
-export function positionDropdown({
+function positionDropdown({
   $opener, $menu,
 
   position = 'bottom',
@@ -422,3 +421,5 @@ export function positionDropdown({
   Object.assign($menu.style, result.style)
   return result
 }
+
+export default Object.assign(Dropdown, { positionDropdown: positionDropdown })

--- a/packages/dropdown/index.js
+++ b/packages/dropdown/index.js
@@ -2,9 +2,9 @@ import React, { PureComponent } from 'react'
 import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import DocumentEvents from 'react-document-events'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 import './index.styl'
-const { trimList, $, SVG } = Util
+const { trimList, $, SVG } = util
 
 const MENU_ROOT_ID = 'MB_DROPDOWN_MENU_ROOT'
 const { I18N = {} } = window

--- a/packages/form/Check.js
+++ b/packages/form/Check.js
@@ -4,10 +4,10 @@ import isArray from 'lodash/isArray'
 import isSet from 'lodash/isSet'
 
 import Icon from '@ibot/icon'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 import { getOptionLabel, getOptionValue } from './util'
 
-const { trimList } = Util
+const { trimList } = util
 
 /**
  * <Check>

--- a/packages/form/Check.js
+++ b/packages/form/Check.js
@@ -4,8 +4,10 @@ import isArray from 'lodash/isArray'
 import isSet from 'lodash/isSet'
 
 import Icon from '@ibot/icon'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 import { getOptionLabel, getOptionValue } from './util'
+
+const { trimList } = Util
 
 /**
  * <Check>

--- a/packages/form/FormEntry.js
+++ b/packages/form/FormEntry.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 
+const { trimList } = Util
 /**
  * <FormEntry>
  */

--- a/packages/form/FormEntry.js
+++ b/packages/form/FormEntry.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
-const { trimList } = Util
+const { trimList } = util
 /**
  * <FormEntry>
  */

--- a/packages/form/Input.js
+++ b/packages/form/Input.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Util from '@ibot/util'
-const { trimList } = Util
+import util from '@ibot/util'
+const { trimList } = util
 
 function createOnChangeHandler(onChange) {
   return e => onChange(e.target.value, e)

--- a/packages/form/Input.js
+++ b/packages/form/Input.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
+const { trimList } = Util
 
 function createOnChangeHandler(onChange) {
   return e => onChange(e.target.value, e)

--- a/packages/form/InputEmail.js
+++ b/packages/form/InputEmail.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import DocumentEvents from 'react-document-events'
-
-import { trimList, getOtherProps, EMAIL_REGEX } from '@ibot/util'
+import Util from '@ibot/util'
+const { trimList, getOtherProps, EMAIL_REGEX } = Util
 
 const checkFinishedTyping = v => (
   /^@/.test(v)

--- a/packages/form/InputEmail.js
+++ b/packages/form/InputEmail.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import DocumentEvents from 'react-document-events'
-import Util from '@ibot/util'
-const { trimList, getOtherProps, EMAIL_REGEX } = Util
+import util from '@ibot/util'
+const { trimList, getOtherProps, EMAIL_REGEX } = util
 
 const checkFinishedTyping = v => (
   /^@/.test(v)

--- a/packages/form/InputNumber.js
+++ b/packages/form/InputNumber.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import DocumentEvents from 'react-document-events'
 
 import Button from '@ibot/button'
-import { trimList, getOtherProps, SVG } from '@ibot/util'
+import Util from '@ibot/util'
 
 import { SelectMenu, $menuRoot } from './Select'
+const { trimList, getOtherProps, SVG } = Util
 
 const LONG_PRESSED_THRESHOLD = 500
 const LONG_PRESSED_STEPPING_INTERVAL = 30

--- a/packages/form/InputNumber.js
+++ b/packages/form/InputNumber.js
@@ -5,10 +5,10 @@ import DocumentEvents from 'react-document-events'
 import isNumber from 'lodash/isNumber'
 
 import Button from '@ibot/button'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import { SelectMenu, $menuRoot } from './Select'
-const { trimList, getOtherProps, SVG } = Util
+const { trimList, getOtherProps, SVG } = util
 
 const LONG_PRESSED_THRESHOLD = 500
 const LONG_PRESSED_STEPPING_INTERVAL = 30

--- a/packages/form/InputNumber.js
+++ b/packages/form/InputNumber.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import DocumentEvents from 'react-document-events'
 
+import isNumber from 'lodash/isNumber'
+
 import Button from '@ibot/button'
 import Util from '@ibot/util'
 
@@ -27,7 +29,14 @@ const getStep = ({ shiftKey, metaKey }, step = 1) => (
 
 export class InputNumber extends PureComponent {
   state = {
-    value: this.props.value || (!!this.props.placeholder ? '' : 1),
+    value: (
+      isNumber(this.props.value)
+      ? this.props.value
+      : !!this.props.placeholder
+      ? ''
+      : 1
+    ),
+
     isActive: false,
     isValid: true,
     isMenuOpen: false,
@@ -203,7 +212,7 @@ export class InputNumber extends PureComponent {
     this.setState({ value: settingNumber, isValid })
 
     if (isValid) {
-      onChange(settingNumber)
+      onChange(settingNumber, e)
     } else {
       Object.assign(this, { correctionTimeout: (
         setTimeout(() => (
@@ -213,7 +222,7 @@ export class InputNumber extends PureComponent {
               value: finalNumber,
               isValid: true,
             },
-            onChange(finalNumber),
+            onChange(finalNumber, e),
           )
         ), CORRECTION_AWAIT)
       )})

--- a/packages/form/Radio.js
+++ b/packages/form/Radio.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
-import Util from '@ibot/util'
+import util from '@ibot/util'
 import { getOptionLabel, getOptionValue, getCurrentOptionIdx } from './util'
-const { trimList } = Util
+const { trimList } = util
 /**
  * <Radio>
  */

--- a/packages/form/Radio.js
+++ b/packages/form/Radio.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 import { getOptionLabel, getOptionValue, getCurrentOptionIdx } from './util'
-
+const { trimList } = Util
 /**
  * <Radio>
  */

--- a/packages/form/Select.js
+++ b/packages/form/Select.js
@@ -5,18 +5,17 @@ import DocumentEvents from 'react-document-events'
 
 import get from 'lodash/get'
 import isArray from 'lodash/isArray'
-import isNumber from 'lodash/isNumber'
-import isString from 'lodash/isString'
 
-import { Ellipsis } from '@ibot/text'
-import Icon from '@ibot/icon'
-import { positionDropdown } from '@ibot/dropdown'
-import { trimList, $, $$, SVG } from '@ibot/util'
-
+import Text from '@ibot/text'
+import Dropdown from '@ibot/dropdown'
+import Util from '@ibot/util'
+import { Input } from './Input'
 import { getOptionValue, getCurrentOptionIdx } from './util'
 
 import './index.styl'
 
+const { Ellipsis: { Ellipsis } } = Text
+const { trimList, $, $$, SVG } = Util
 const MENU_ROOT_ID = 'MB_SELECT_MENU_ROOT'
 const CANT_SCROLL_CLASS = 'mb-cant-scroll'
 
@@ -275,7 +274,7 @@ export class SelectMenu extends PureComponent {
 
     // Set up the position of the <SelectMenu> once opened:
     if (!isOpen && willBeOpen) {
-      const result = positionDropdown({
+      const result = Dropdown.positionDropdown({
         $menu,
         $opener: $select,
         position: 'bottom',

--- a/packages/form/Select.js
+++ b/packages/form/Select.js
@@ -8,14 +8,14 @@ import isArray from 'lodash/isArray'
 
 import Text from '@ibot/text'
 import Dropdown from '@ibot/dropdown'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 import { Input } from './Input'
 import { getOptionValue, getCurrentOptionIdx } from './util'
 
 import './index.styl'
 
 const { Ellipsis: { Ellipsis } } = Text
-const { trimList, $, $$, SVG } = Util
+const { trimList, $, $$, SVG } = util
 const MENU_ROOT_ID = 'MB_SELECT_MENU_ROOT'
 const CANT_SCROLL_CLASS = 'mb-cant-scroll'
 

--- a/packages/form/index.js
+++ b/packages/form/index.js
@@ -1,7 +1,11 @@
 import './index.styl'
 
-export { FormEntry, FormLabel } from './FormEntry'
-export * from './Input'
-export { Check, CheckGroup } from './Check'
-export { Radio, RadioGroup } from './Radio'
-export Select, { PanelSelect } from './Select'
+import { FormEntry, FormLabel } from './FormEntry'
+import * as Input from './Input'
+import { Check, CheckGroup } from './Check'
+import { Radio, RadioGroup } from './Radio'
+import Select, { PanelSelect } from './Select'
+
+export default {
+  FormEntry, FormLabel, Input, Check, CheckGroup, Radio, RadioGroup, Select, PanelSelect
+}

--- a/packages/guide/index.js
+++ b/packages/guide/index.js
@@ -94,6 +94,10 @@ export default class GuideBase extends PureComponent {
     }
   }
 
+  componentWillUnmount() {
+    if (this.portal) this.portal.remove()
+  }
+
   position = () => {
     const { $base, $guide } = this
     const { position, inflexible } = this.props

--- a/packages/guide/index.js
+++ b/packages/guide/index.js
@@ -6,11 +6,13 @@ import DocumentEvents from 'react-document-events'
 
 import Button from '@ibot/button'
 import Icon from '@ibot/icon'
-import { trimList, $, SVG } from '@ibot/util'
-import { positionDropdown } from '@ibot/dropdown'
+import util from '@ibot/util'
+import Dropdown from '@ibot/dropdown'
 
 import './index.styl'
 
+const { positionDropdown } = Dropdown
+const { trimList, SVG } = util
 const { I18N = {} } = window
 const GUIDE_ROOT_ID = 'MB_GUIDE_GUIDE_ROOT'
 

--- a/packages/guide/index.styl
+++ b/packages/guide/index.styl
@@ -62,14 +62,17 @@
     position relative
     padding 1.5em 1.5em 1em
     min-height 32px
+    font-size 14px
+    line-height 2
     background-color #fff
     border-radius 4px
     color $cl-tertiary-grey
 
   header
-    margin .25em 0 .5em
+    margin .25em 0 10px
     font-size 16px
     font-weight bold
+    line-height 1.2
     color $cl-primary-grey
 
   .close-btn
@@ -84,5 +87,9 @@
       height @width
 
   footer
-    margin-top .75em
-    text-align end
+    &
+      margin-top .75em
+      text-align end
+    button:not([disabled]):hover
+      text-decoration none
+      opacity .8

--- a/packages/icon/index.js
+++ b/packages/icon/index.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 
 import duoList from 'mb-icons/dora/duo-list.json'
 import './index.styl'
-
+const { trimList } = Util
 const ICON_SET_LIST = ['dora', 'mb', 'icon', 'fa', 'md', 'ci']
 const LIGA_ICON_SET_LIST = ['dora', 'md']
 

--- a/packages/icon/index.js
+++ b/packages/icon/index.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import duoList from 'mb-icons/dora/duo-list.json'
 import './index.styl'
-const { trimList } = Util
+const { trimList } = util
 const ICON_SET_LIST = ['dora', 'mb', 'icon', 'fa', 'md', 'ci']
 const LIGA_ICON_SET_LIST = ['dora', 'md']
 

--- a/packages/modal/index.js
+++ b/packages/modal/index.js
@@ -6,11 +6,11 @@ import DocumentEvents from 'react-document-events'
 import Button from '@ibot/button'
 import Switch from '@ibot/switch'
 import Icon from '@ibot/icon'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import './index.styl'
 
-const { trimList, $ } = Util
+const { trimList, $ } = util
 const OPEN_MODAL_STACK = []
 const { I18N = {} } = window
 

--- a/packages/modal/index.js
+++ b/packages/modal/index.js
@@ -6,10 +6,11 @@ import DocumentEvents from 'react-document-events'
 import Button from '@ibot/button'
 import Switch from '@ibot/switch'
 import Icon from '@ibot/icon'
-import { trimList, $ } from '@ibot/util'
+import Util from '@ibot/util'
 
 import './index.styl'
 
+const { trimList, $ } = Util
 const OPEN_MODAL_STACK = []
 const { I18N = {} } = window
 

--- a/packages/switch/index.js
+++ b/packages/switch/index.js
@@ -2,10 +2,11 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import Icon from '@ibot/icon'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 
 import './index.styl'
 
+const { trimList } = Util
 class Switch extends PureComponent {
   constructor(props) {
     super(props)

--- a/packages/switch/index.js
+++ b/packages/switch/index.js
@@ -2,11 +2,11 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import Icon from '@ibot/icon'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import './index.styl'
 
-const { trimList } = Util
+const { trimList } = util
 class Switch extends PureComponent {
   constructor(props) {
     super(props)

--- a/packages/text/Ellipsis.js
+++ b/packages/text/Ellipsis.js
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash/isEqual'
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import Tooltip from './Tooltip'
 
 import { TYPE_ELEMENT_MAP } from './constants'
-const { trimList } = Util
+const { trimList } = util
 export class Ellipsis extends PureComponent {
   state = { isTruncated: false }
 

--- a/packages/text/Ellipsis.js
+++ b/packages/text/Ellipsis.js
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash/isEqual'
-import { trimList } from '@ibot/util'
+import Util from '@ibot/util'
 
 import Tooltip from './Tooltip'
 
 import { TYPE_ELEMENT_MAP } from './constants'
-
+const { trimList } = Util
 export class Ellipsis extends PureComponent {
   state = { isTruncated: false }
 

--- a/packages/text/Tooltip.js
+++ b/packages/text/Tooltip.js
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types'
 import isString from 'lodash/isString'
 import isArray from 'lodash/isArray'
 
-import { trimList, getOtherProps, SVG } from '@ibot/util'
+import Util from '@ibot/util'
 
 import { TYPE_ELEMENT_MAP } from './constants'
 
+const { trimList, getOtherProps, SVG } = Util
 const EVENT_NAME_LIST = ['hover', 'click']
 
 const TIP_ROOT_ID = 'MB_TOOLTIP_ROOT'

--- a/packages/text/Tooltip.js
+++ b/packages/text/Tooltip.js
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types'
 import isString from 'lodash/isString'
 import isArray from 'lodash/isArray'
 
-import Util from '@ibot/util'
+import util from '@ibot/util'
 
 import { TYPE_ELEMENT_MAP } from './constants'
 
-const { trimList, getOtherProps, SVG } = Util
+const { trimList, getOtherProps, SVG } = util
 const EVENT_NAME_LIST = ['hover', 'click']
 
 const TIP_ROOT_ID = 'MB_TOOLTIP_ROOT'

--- a/packages/text/index.js
+++ b/packages/text/index.js
@@ -1,4 +1,6 @@
 import './index.styl'
 
-export * from './Ellipsis'
-export Tooltip from './Tooltip'
+import * as Ellipsis from './Ellipsis'
+import Tooltip from './Tooltip'
+
+export default { Ellipsis, Tooltip }

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -3,13 +3,13 @@ import './polyfill'
 
 import './index.styl'
 
-export const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 
-export function trimList(list) {
+function trimList(list) {
   return compact(list).join(' ')
 }
 
-export function getOtherProps({ propTypes = {} }, props) {
+function getOtherProps({ propTypes = {} }, props) {
   const propKeyList = Object.keys(propTypes)
 
   return Object.entries(props).reduce(
@@ -22,12 +22,15 @@ export function getOtherProps({ propTypes = {} }, props) {
   )
 }
 
-export function $(selector, context = document) {
+function $(selector, context = document) {
   return context.querySelector(selector)
 }
 
-export function $$(selector, context = document) {
+function $$(selector, context = document) {
   return Array.from(context.querySelectorAll(selector))
 }
 
-export * as SVG from './svg'
+import * as SVG from './svg'
+
+
+export default { EMAIL_REGEX, trimList, getOtherProps, $, $$, SVG }

--- a/stories/dropdown.js
+++ b/stories/dropdown.js
@@ -6,8 +6,11 @@ import Root from '../packages/root/index'
 import Icon from '../packages/icon/index'
 import Dropdown from '../packages/dropdown/index'
 
-import { Select, Check } from '../packages/form/index'
-import { Tooltip } from '../packages/text/index'
+import Form from '../packages/form/index'
+import Text from '../packages/text/index'
+
+const { Select, Check } = Form
+const { Tooltip } = Text
 
 storiesOf('Dropdown', module)
 .add('Default', () => (

--- a/stories/form/InputEmail.js
+++ b/stories/form/InputEmail.js
@@ -1,21 +1,15 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import Root from '../../packages/root/index'
-import Icon from '../../packages/icon/index'
-import Switch from '../../packages/switch/index'
 import Button from '../../packages/button/index'
 
-import {
-  FormLabel, FormEntry,
-  Input, PanelInput,
-  Textarea,
-  InputEmail, PanelInputEmail,
-  Radio, Check,
-  RadioGroup, CheckGroup,
-  Select,
-} from '../../packages/form/index'
+import Form from '../../packages/form/index'
+
+const {
+  FormLabel,
+  Input: { InputEmail, PanelInputEmail }
+} = Form
 
 export default class InputEmailExample extends React.PureComponent {
   constructor(props) {
@@ -24,7 +18,7 @@ export default class InputEmailExample extends React.PureComponent {
   }
 
   onChange = (name, value, e) => this.setState(
-    ({ formData }) => ({ formData: { ...formData, [name]: value }}),
+    ({ formData }) => ({formData: { ...formData, [name]: value }}),
     () => action('Email changed')(value, e),
   )
 

--- a/stories/form/InputNumber.js
+++ b/stories/form/InputNumber.js
@@ -1,22 +1,16 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import Root from '../../packages/root/index'
 import Icon from '../../packages/icon/index'
-import Switch from '../../packages/switch/index'
 import Button from '../../packages/button/index'
 
-import {
-  FormLabel, FormEntry,
-  Input, PanelInput,
-  Textarea,
-  InputNumber, PanelInputNumber,
-  SelectNumber, PanelSelectNumber,
-  Radio, Check,
-  RadioGroup, CheckGroup,
-  Select,
-} from '../../packages/form/index'
+import Form from '../../packages/form/index'
+
+const {
+  FormLabel,
+  Input: { InputNumber, SelectNumber, PanelInputNumber, PanelSelectNumber },
+} = Form
 
 export default class InputNumberExample extends React.PureComponent {
   constructor(props) {
@@ -25,7 +19,7 @@ export default class InputNumberExample extends React.PureComponent {
   }
 
   onChange = (name, value, e) => this.setState(
-    ({ formData }) => ({ formData: { ...formData, [name]: value }}),
+    ({ formData }) => ({formData: { ...formData, [name]: value }}),
     () => action('Number changed')(value, e),
   )
 

--- a/stories/form/InputNumber.js
+++ b/stories/form/InputNumber.js
@@ -13,10 +13,7 @@ const {
 } = Form
 
 export default class InputNumberExample extends React.PureComponent {
-  constructor(props) {
-    super(props)
-    this.state = { formData: {}, isSmall: false }
-  }
+  state = { formData: { a: 0 }, isSmall: false }
 
   onChange = (name, value, e) => this.setState(
     ({ formData }) => ({formData: { ...formData, [name]: value }}),

--- a/stories/form/RadioCheck.js
+++ b/stories/form/RadioCheck.js
@@ -7,7 +7,9 @@ import Icon from '../../packages/icon/index'
 import Switch from '../../packages/switch/index'
 import Button from '../../packages/button/index'
 
-import {
+import Form from '../../packages/form/index'
+
+const {
   FormLabel, FormEntry,
   Input, PanelInput,
   Textarea,
@@ -15,7 +17,7 @@ import {
   Radio, Check,
   RadioGroup, CheckGroup,
   Select,
-} from '../../packages/form/index'
+} = Form
 
 export default class RadioCheckExample extends PureComponent {
   constructor(props) {
@@ -254,4 +256,3 @@ export default class RadioCheckExample extends PureComponent {
     )
   }
 }
-

--- a/stories/form/Select.js
+++ b/stories/form/Select.js
@@ -7,7 +7,9 @@ import Icon from '../../packages/icon/index'
 import Switch from '../../packages/switch/index'
 import Button from '../../packages/button/index'
 
-import {
+import Form from '../../packages/form/index'
+
+const {
   FormLabel, FormEntry,
   Input, PanelInput,
   Textarea,
@@ -15,7 +17,7 @@ import {
   Radio, Check,
   RadioGroup, CheckGroup,
   Select, SelectNumber,
-} from '../../packages/form/index'
+} = Form
 
 export default class SelectExample extends React.PureComponent {
   state = { isSmall: false, longerSelectValue: 'Taller Men' }

--- a/stories/form/index.js
+++ b/stories/form/index.js
@@ -5,22 +5,20 @@ import { action } from '@storybook/addon-actions'
 import Root from '../../packages/root/index'
 import Icon from '../../packages/icon/index'
 import Switch from '../../packages/switch/index'
-import Button from '../../packages/button/index'
-
-import {
-  FormLabel, FormEntry,
-  Input, PanelInput,
-  Textarea, PanelTextarea,
-  InputNumber,
-  Radio, Check,
-  RadioGroup, CheckGroup,
-  Select,
-} from '../../packages/form/index'
+import Form from '../../packages/form/index'
 
 import InputEmailExample from './InputEmail'
 import InputNumberExample from './InputNumber'
 import RadioCheckExample from './RadioCheck'
 import SelectExample from './Select'
+
+const {
+  FormLabel, FormEntry,
+  Input: { Input, PanelInput, Textarea, PanelTextarea, InputNumber },
+  Check,
+  RadioGroup, CheckGroup,
+  Select,
+} = Form
 
 const onTypingChange = action('Typing changed')
 

--- a/stories/modal.js
+++ b/stories/modal.js
@@ -7,15 +7,18 @@ import Icon from '../packages/icon/index'
 import Switch from '../packages/switch/index'
 import Modal from '../packages/modal/index'
 
-import {
+import Form from '../packages/form/index'
+
+import Text from '../packages/text/index'
+
+const  {
   FormLabel, FormEntry,
-  Input, InputNumber, Textarea,
-  Radio, Check,
+  Input: { InputNumber, Textarea, Input },
   RadioGroup, CheckGroup,
   Select,
-} from '../packages/form/index'
+} = Form
 
-import { WidgetName } from '../packages/text/index'
+const { Ellipsis: { WidgetName } } = Text
 
 storiesOf('Modal', module)
 .add('Default', () => (

--- a/stories/text/ellipsis-i.js
+++ b/stories/text/ellipsis-i.js
@@ -1,15 +1,11 @@
 import React, { PureComponent } from 'react'
-import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 
 import Root from '../../packages/root/index'
-import Icon from '../../packages/icon/index'
-import Button from '../../packages/button/index'
-import { Textarea } from '../../packages/form/index'
-import {
-  Tooltip, Ellipsis,
-  User, TeamName, AppName, WidgetName,
-} from '../../packages/text/index'
+import Text from '../../packages/text/index'
+
+const {
+  Ellipsis: { Ellipsis } ,
+} = Text
 
 export default class EllipsisI extends PureComponent {
   render() {

--- a/stories/text/ellipsis-ii.js
+++ b/stories/text/ellipsis-ii.js
@@ -1,15 +1,12 @@
 import React, { PureComponent } from 'react'
-import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 
 import Root from '../../packages/root/index'
-import Icon from '../../packages/icon/index'
 import Button from '../../packages/button/index'
-import { Textarea } from '../../packages/form/index'
-import {
-  Tooltip, Ellipsis,
-  User, TeamName, AppName, WidgetName,
-} from '../../packages/text/index'
+import Text from '../../packages/text/index'
+
+const {
+  Ellipsis: { User, TeamName, AppName, WidgetName },
+} = Text
 
 const shortName = 'Vincent'
 const longName = 'Mitchell Vincent Pritchett'

--- a/stories/text/ellipsis-iii.js
+++ b/stories/text/ellipsis-iii.js
@@ -1,16 +1,11 @@
 import React, { PureComponent } from 'react'
-import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 
 import Root from '../../packages/root/index'
-import Icon from '../../packages/icon/index'
-import Button from '../../packages/button/index'
-import { Textarea } from '../../packages/form/index'
-import {
-  Tooltip, Ellipsis,
-  User, TeamName, AppName, WidgetName,
-} from '../../packages/text/index'
+import Text from '../../packages/text/index'
 
+const {
+  Ellipsis: { User, TeamName },
+} = Text
 export default class EllipsisIII extends PureComponent {
   render() {
     return (

--- a/stories/text/index.js
+++ b/stories/text/index.js
@@ -1,15 +1,5 @@
-import React, { PureComponent } from 'react'
+import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
-
-import Root from '../../packages/root/index'
-import Icon from '../../packages/icon/index'
-import Button from '../../packages/button/index'
-import { Textarea } from '../../packages/form/index'
-import {
-  Tooltip, Ellipsis,
-  User, TeamName, AppName, WidgetName,
-} from '../../packages/text/index'
 
 import TooltipExample from './tooltip'
 import EllipsisI from './ellipsis-i'

--- a/stories/text/tooltip.js
+++ b/stories/text/tooltip.js
@@ -1,15 +1,15 @@
 import React, { PureComponent } from 'react'
-import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 
 import Root from '../../packages/root/index'
 import Icon from '../../packages/icon/index'
 import Button from '../../packages/button/index'
-import { Textarea } from '../../packages/form/index'
-import {
-  Tooltip, Ellipsis,
-  User, TeamName, AppName, WidgetName,
-} from '../../packages/text/index'
+import Form from '../../packages/form/index'
+import Text from '../../packages/text/index'
+
+const { Input: { Textarea } } = Form
+const {
+  Tooltip
+} = Text
 
 export default class TooltipExample extends PureComponent {
   constructor(props) {


### PR DESCRIPTION
This change tends to make ibot has better integration with bable-import-plugin, which would help users loading resources on demand. Although we have supported it already, but not perfectly. The reason is we were using named export somewhere in this codebase but bable-plugin-import has the limitation towards this since it can only (on my perspective) find the right entry module witch default export, which means users would right the entire path to import the module they want, both js and css.
That would also be erorr prone because they may forget to import the styles.

So I changed the export on the surface to the default export, this change is a *break change* cause it requires users to tweak their code some cases like `form` component.

And shame on me, I broke the SEMVER again for publishing the wrong version to the wild.