### PR TITLE
CHG: handle `onClickOutside` on click instead of mousedown

### DIFF
--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -397,7 +397,7 @@ class DropdownMenu extends PureComponent {
 
           <DocumentEvents
             enabled={isOpen}
-            onMouseDown={this.onClickOutside}
+            onClick={this.onClickOutside}
           />
 
           <DocumentEvents

--- a/components/form/ConfirmInputNumber.js
+++ b/components/form/ConfirmInputNumber.js
@@ -546,7 +546,7 @@ export class ConfirmInputNumber extends PureComponent {
 
         <DocumentEvents
           enabled={isActive || isMenuOpen}
-          onMouseDown={this.onClickOutside}
+          onClick={this.onClickOutside}
           onKeyDown={this.onKeyDown}
         />
       </label>

--- a/components/form/InputEmail.js
+++ b/components/form/InputEmail.js
@@ -145,7 +145,7 @@ export class InputEmail extends PureComponent {
 
         <DocumentEvents
           enabled={isActive}
-          onMouseDown={this.onClickOutside}
+          onClick={this.onClickOutside}
         />
       </label>
     )

--- a/components/form/InputNumber.js
+++ b/components/form/InputNumber.js
@@ -433,7 +433,7 @@ export class InputNumber extends PureComponent {
 
         <DocumentEvents
           enabled={isActive || isMenuOpen}
-          onMouseDown={this.onClickOutside}
+          onClick={this.onClickOutside}
         />
       </label>
     )


### PR DESCRIPTION
将以下组件中的`onClickOutside`方法放在`click`事件中调用（原为`mousedown`）：
`<Dropdown>`
`<InputNumber>`
`<ConfirmInputNumber>`
`<InputEmail>`