### PR TITLE
FIX: escape `content` string value

### DIFF
--- a/components/text/Ellipsis.styl
+++ b/components/text/Ellipsis.styl
@@ -44,35 +44,35 @@
     &:after
       content '. '
     &:lang(zh):after
-      content '。'
+      content '\3002' // '。'
   &.with-comma
     &:after
       content ', '
     &:lang(zh):after
-      content '，'
+      content '\FF0C' // '，'
   &.with-question-mark
     &:after
       content '? '
     &:lang(zh):after
-      content '？'
+      content '\FF1F' // '？'
   &.with-quote
     &:before
-      content '“'
+      content '\201C' // '“'
     &:after
-      content '”'
+      content '\201D' // '”'
     &.with-period:after
-      content '”. '
+      content '\201D. ' // '”. '
     &.with-comma:after
-      content '”, '
+      content '\201D, ' // '”, '
     &.with-question-mark:after
-      content '”? '
+      content '\201D? ' // '”? '
     &:lang(zh):before
-      content '「'
+      content '\300C' // '「'
     &:lang(zh):after
-      content '」'
+      content '\300D' // '」'
     &.with-period:lang(zh):after
-      content '」。'
+      content '\300D\3002' // '」。'
     &.with-comma:lang(zh):after
-      content '」，'
+      content '\300D\FF0C' // '」，'
     &.with-question-mark:lang(zh):after
-      content '」？'
+      content '\300D\FF1F' // '」？'


### PR DESCRIPTION
Strangely, previous `.css` is usable because our webpack [`css-loader@1`](https://www.npmjs.com/package/css-loader/v/1.0.1) have a dependency of `css-selector-tokenizer`, which will re-escape all css id/string in the parsed css token tree.
Since `css-loader@>=2`, this dependency is gone, and plugin for this is really rare, so the value should be escaped form the source.
